### PR TITLE
Amended the typo in acronym for NCSS 

### DIFF
--- a/_agencies/Participating Agencies.md
+++ b/_agencies/Participating Agencies.md
@@ -55,7 +55,7 @@ variant: markdown
 | Ministry of Trade &amp; Industry    | MTI| - | 
 | Majlis Ugama Islam Singapura    | MUIS| - | 
 | Nanyang Polytechnic    | NYP| - | 
-| National Council of Social Service    | NCCS| - | 
+| National Council of Social Service    | NCSS| - | 
 | National Environment Agency    | NEA| -|
 | National Heritage Board   | NHB| - |     
 | National Library Board    | NLB| - | 


### PR DESCRIPTION
National Council of Social Service should be "NCSS" instead of "NCCS" 